### PR TITLE
Improve VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,33 @@
 
     "todo-tree.filtering.excludeGlobs": [
         "/.venv/*/**" // Prevent TODO Tree extension from looking inside the virtual environment
-    ]
+    ],
 
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+
+    // Configure Outline to only show constants, classes, methods, and functions
+    "outline.showConstants": true,
+    "outline.showClasses": true,
+    "outline.showMethods": true,
+    "outline.showFunctions": true,
+    "outline.showVariables": false,
+    "outline.showModules": false,
+    "outline.showPackages": false,
+    "outline.showProperties": false,
+    "outline.showFields": false,
+    "outline.showConstructors": false,
+    "outline.showEnums": false,
+    "outline.showInterfaces": false,
+    "outline.showNamespaces": false,
+    "outline.showStrings": false,
+    "outline.showKeys": false,
+    "outline.showNumbers": false,
+    "outline.showBooleans": false,
+    "outline.showArrays": false,
+    "outline.showObjects": false,
+    "outline.showNull": false,
+    "outline.showEnumMembers": false,
+    "outline.showEvents": false,
+    "outline.showOperators": false,
+    "outline.showTypeParameters": false
 }


### PR DESCRIPTION
1. Record the venv as the interpreter, so it doesn't reset (as much).
2. Hide most things from the Outline in the Explorer pane, so it's actually useful.